### PR TITLE
fix: use `require.resolve` for extends

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,7 @@
 import { defineNuxtConfig } from 'nuxt'
 
 export default defineNuxtConfig({
-  extends: ['./node_modules/@docus/docs-theme'],
+  extends: [require.resolve('@docus/docs-theme')],
   github: {
     repo: 'nuxtlabs/docus-starter'
   }


### PR DESCRIPTION
Until https://github.com/unjs/c12/pull/19 arrives, this is a safer solution to avoid depending on direct `node_modules` path.