### PR TITLE
fix(lint): remove unnecessary comma in app config

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -5,7 +5,7 @@ export default defineAppConfig({
     image: 'https://user-images.githubusercontent.com/904724/185365452-87b7ca7b-6030-4813-a2db-5e65c785bf88.png',
     socials: {
       twitter: 'nuxt_themes',
-      github: 'nuxt-themes/docus',
+      github: 'nuxt-themes/docus'
     },
     aside: {
       level: 0,


### PR DESCRIPTION
When the starter is deployed from Studio on an existing repository with strict lint rules, this unnecessary comma breaks the lint. 